### PR TITLE
feat: add fullscreen mode to Martek translator

### DIFF
--- a/adventures/martek/app.js
+++ b/adventures/martek/app.js
@@ -13,6 +13,14 @@
   const lightbox = document.getElementById('lightbox');
   const pdfFull = document.getElementById('pdfFull');
   const closeLightbox = document.getElementById('closeLightbox');
+  const controls = document.querySelector('.controls');
+
+  // кнопка включения полноэкранного режима
+  const fullscreenBtn = document.createElement('button');
+  fullscreenBtn.id = 'fullscreenBtn';
+  fullscreenBtn.textContent = '⤢';
+  fullscreenBtn.title = 'Полноэкранный режим';
+  controls.appendChild(fullscreenBtn);
 
   // State
   let page = 1;
@@ -134,6 +142,21 @@
   }
   pdfWrap.addEventListener('click', ()=> toggleLightbox(true));
   closeLightbox.addEventListener('click', ()=> toggleLightbox(false));
+
+  // переключение полноэкранного режима
+  fullscreenBtn.addEventListener('click', ()=>{
+    const entering = !document.body.classList.contains('fullscreen');
+    document.body.classList.toggle('fullscreen');
+    if(entering){
+      fullscreenBtn.classList.add('floating');
+      fullscreenBtn.textContent = '⤡';
+      document.body.appendChild(fullscreenBtn);
+    }else{
+      fullscreenBtn.classList.remove('floating');
+      fullscreenBtn.textContent = '⤢';
+      controls.appendChild(fullscreenBtn);
+    }
+  });
 
   // Initialize
   render();

--- a/adventures/martek/style.css
+++ b/adventures/martek/style.css
@@ -11,6 +11,9 @@ body{margin:0; background:var(--bg); color:var(--text); font:15px/1.55 system-ui
 .controls button{padding:.45rem .7rem; background:#151a22; color:var(--text); border:1px solid var(--border); border-radius:8px; cursor:pointer}
 .controls button:hover{border-color:#313847; box-shadow:0 0 0 2px #000 inset}
 
+/* кнопка перехода в полноэкранный режим всплывает при скрытой шапке */
+#fullscreenBtn.floating{position:fixed; top:10px; right:10px; z-index:30}
+
 .split{display:grid; grid-template-columns:1fr 1fr; gap:10px; padding:10px}
 @media (max-width: 900px){ .split{grid-template-columns:1fr}}
 
@@ -32,3 +35,11 @@ body{margin:0; background:var(--bg); color:var(--text); font:15px/1.55 system-ui
 .lightbox iframe{position:absolute; inset:0; width:100%; height:100%; border:0; background:#fff}
 
 .footer{padding:.8rem 1rem; color:var(--muted); border-top:1px solid var(--border)}
+
+/* полноэкранный режим: скрываем лишние панели */
+body.fullscreen .header,
+body.fullscreen .pane.original,
+body.fullscreen .footer{display:none}
+
+body.fullscreen .split{grid-template-columns:1fr; gap:0; padding:0; height:100vh}
+body.fullscreen .pane.translation{min-height:100vh}


### PR DESCRIPTION
## Summary
- add fullscreen toggle button for the Martek translation tool
- hide header and original PDF pane in fullscreen mode to focus on translation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bdadd928e88328aa4eb28aa5435dd9